### PR TITLE
refactor message parsing

### DIFF
--- a/src/irc/message.rs
+++ b/src/irc/message.rs
@@ -4,26 +4,34 @@ pub struct Message<'a> {
   pub params: Vec<&'a str>,
 }
 
-impl Message<'_> {
-  pub fn from_string<'m>(line: &'m str) -> Result<Message<'m>, std::io::Error> {
+impl<'m> Message<'m> {
+  pub fn from_string(line: &'m str) -> Option<Message<'m>> {
     let mut parts = line.split(' ');
-    let prefix = if line.get(0..1).unwrap() == ":" {
-      parts.next()
-    } else {
-      None
-    };
 
-    Ok(Message {
+    let prefix = line.chars().nth(0)
+        .and_then(|c| {
+            if c == ':' {
+                parts.next()
+            } else {
+                None
+            }
+        });
+
+    let command = parts.next()?;
+
+    let params = parts.collect();
+
+    Some(Message {
       prefix,
-      command: parts.next().unwrap(),
-      params: parts.collect(),
+      command,
+      params,
     })
   }
 }
 
 #[test]
 fn can_create_message() {
-    let m = (Message::from_string(":me!me@irc.gitter.im JOIN #mychannel")).unwrap();
+    let m = Message::from_string(":me!me@irc.gitter.im JOIN #mychannel").unwrap();
     assert_eq!(m.prefix, Some(":me!me@irc.gitter.im"));
     assert_eq!(m.command, "JOIN");
     assert_eq!(m.params[0], "#mychannel");

--- a/src/irc/mod.rs
+++ b/src/irc/mod.rs
@@ -54,13 +54,14 @@ impl<'imp> Session<'imp> {
     })
   }
 
-  pub async fn handle_lines(&mut self) -> Result<(), std::io::Error> {
+  pub async fn handle_lines(&mut self) -> Result<(), Box<dyn std::error::Error>> {
     let mut count = 0;
     loop {
       let mut response = String::new();
       self.stream.read_line(&mut response).await?;
       {
-        let message = Message::from_string(&response)?;
+        let message = Message::from_string(&response)
+            .ok_or("Could not parse message")?;
         for info in &self.handlers {
             (info.f)(&message);
         }


### PR DESCRIPTION
Hi! I saw your call for feedback on twitter, if you don't mind I have some suggestions here.

- refactored 'message' module
  - changed `from_string` to return `Option` instead of `Result` for now, since there's nothing internally returning `Result`.  If you want to pass along more info on error, you'd probably have to start defining an `Error` enum.
  - More clearly align lifetime of `Message` with the line it's referencing.
  - use `chars`, which might be more idiomatic? This is probably not a big deal.
  - remove unwrap. The first is changed to `and_then`, since you don't want to early return. The second is turned into `?` for now, since it looks like it could early return.

- Changed `handle_lines` to return `Box<dyn std::error::Error>`, since there's two types of errors that can be returned internally.
  - since `Message::from_string` returns an `Option` for now, I use `ok_or` to turn that into a `Result`

Three other overall notes:
- error handling is probably the next big step. Let me know if you have any questions about it, there's currently a lot to navigate.
- You wrote a `from_string` method; there's a `FromStr` trait in `std`, which I would generally recommend implementing.
- You use `&str` for `nick` and `label` in your `LineHandler` and `Session` structs; I think that this may complicate lifetimes down the road for not much gain. I don't think it hurts for these structs to own their `label` and `nick` data and I don't think there's much any performance gain in referencing. Using `&str` does make sense for `Message` though.

Let me know if you have any other questions, thanks for writing this tutorial!