### PR TITLE
Add errors and tests for parsing Message

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,10 @@
-use std::fmt;
+use std::{fmt, io};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Error {
     MessageMissingCommand,
     MessageStringTooLong,
+    Network(io::Error),
 }
 
 impl fmt::Display for Error {
@@ -11,8 +12,15 @@ impl fmt::Display for Error {
         match self {
             Error::MessageMissingCommand => write!(f, "Message Missing Command"),
             Error::MessageStringTooLong => write!(f, "Message String To Long"),
+            Error::Network(err) => write!(f, "Network error: {}", err),
         }
     }
 }
 
 impl std::error::Error for Error {}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Self::Network(err)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,18 @@
+use std::fmt;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Error {
+    MessageMissingCommand,
+    MessageStringTooLong,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), std::fmt::Error> {
+        match self {
+            Error::MessageMissingCommand => write!(f, "Message Missing Command"),
+            Error::MessageStringTooLong => write!(f, "Message String To Long"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src/irc/mod.rs
+++ b/src/irc/mod.rs
@@ -57,7 +57,8 @@ impl<Connection: AsyncRead + AsyncWrite + Unpin> Protocol<Connection> {
       let mut response = String::new();
       self.bufconn.read_line(&mut response).await?;
       {
-        let message = Message::from_string(&response).ok_or("Could not parse message")?;
+        let message = Message::from_string(&response)?;
+
         for info in &self.handlers {
           (info.f)(&message);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,16 @@
-use std::error::Error;
+pub mod error;
+mod message;
 
 use tokio::prelude::*;
 use tokio::{io::BufReader, net::TcpStream};
 
-pub mod message;
-pub use self::message::Message; // Re-export `Message` as part of irc module
+pub use crate::message::Message; // Re-export `Message` as part of irc module
+use crate::error::Error;
 
 type LineHandler = fn(line: &Message) -> ();
 
 struct LineHandlerInfo {
+  #[allow(dead_code)]
   label: String,
   f: LineHandler,
 }
@@ -29,21 +31,21 @@ impl<Connection: AsyncRead + AsyncWrite + Unpin> Protocol<Connection> {
     }
   }
 
-  pub async fn connect(&mut self, pass: &str) -> Result<(), Box<dyn Error>> {
+  pub async fn connect(&mut self, pass: &str) -> Result<(), Error> {
     let connect_str = format!(
       "PASS {pass}\r\nNICK {name}\r\nUSER {name} 0 * {name}\r\n",
       pass = pass,
       name = self.nick
     );
     self.bufconn.write_all(connect_str.as_bytes()).await?;
-
     Ok(())
   }
 
   // TODO: maybe name this send_command
-  pub async fn command(&mut self, cmd_str: &str) -> Result<(), std::io::Error> {
+  pub async fn command(&mut self, cmd_str: &str) -> Result<(), Error> {
     println!("command: {:?}", cmd_str);
-    self.bufconn.write_all(cmd_str.as_bytes()).await
+    self.bufconn.write_all(cmd_str.as_bytes()).await?;
+    Ok(())
   }
 
   // TODO: why not &'imp mut self ???
@@ -51,7 +53,7 @@ impl<Connection: AsyncRead + AsyncWrite + Unpin> Protocol<Connection> {
     self.handlers.push(LineHandlerInfo { label, f })
   }
 
-  pub async fn handle_lines(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+  pub async fn handle_lines(&mut self) -> Result<(), Error> {
     let mut count = 0;
     loop {
       let mut response = String::new();
@@ -72,53 +74,8 @@ impl<Connection: AsyncRead + AsyncWrite + Unpin> Protocol<Connection> {
   }
 }
 
-// impl<'imp> Session<'imp> {
-//   pub async fn new<'a>(addr: &'a str, nick: &'a str) -> Result<Session<'a>, Box<dyn Error>> {
-//     let tcp = TcpStream::connect(addr).await?;
-//     let stream = BufReader::new(tcp);
-//     Ok(Session {
-//       nick,
-//       stream,
-//       handlers: Vec::new(),
-//     })
-//   }
-
-//   // TODO: maybe name this send_command
-//   pub async fn command<'a>(&'a mut self, cmd_str: &'a str) -> Result<(), std::io::Error> {
-//     self.stream.write_all(cmd_str.as_bytes()).await
-//   }
-
-//   // TODO: why not &'imp mut self ???
-//   pub fn register_handler(&mut self, label: &'imp str, f: LineHandler) {
-//     self.handlers.push(LineHandlerInfo {
-//       label,
-//       f,
-//     })
-//   }
-
-//   pub async fn handle_lines(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-//     let mut count = 0;
-//     loop {
-//       let mut response = String::new();
-//       self.stream.read_line(&mut response).await?;
-//       {
-//         let message = Message::from_string(&response)
-//             .ok_or("Could not parse message")?;
-//         for info in &self.handlers {
-//             (info.f)(&message);
-//         }
-//       }
-//       count += 1;
-//       if count > 18 {break};
-//     };
-//     Ok(())
-//   }
-
-// }
-
 #[tokio::test]
 async fn can_create_protocol() {
-  use tokio::io::{AsyncReadExt, AsyncWriteExt};
   use tokio_test::io::Builder;
   use tokio_test::io::Mock;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
+mod error;
+mod irc;
+
 use std::env;
 use std::error::Error;
 use tokio::net::TcpStream;
-
-mod irc;
 
 //https://docs.rs/tokio/0.2.0-alpha.5/tokio/net/tcp/struct.TcpStream.html
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,4 @@
-mod error;
-mod irc;
-
+use irc_tokio as irc;
 use std::env;
 use std::error::Error;
 use tokio::net::TcpStream;

--- a/src/message.rs
+++ b/src/message.rs
@@ -44,6 +44,9 @@ impl<'m> Message<'m> {
 mod test {
     use super::*;
 
+    // TODO use a macro to match error enum variant
+    // Since we can't use PartialEq, only pattern matching
+
     #[test]
     fn can_create_message() {
         let m = Message::from_string(":me!me@irc.gitter.im JOIN #mychannel").unwrap();
@@ -55,10 +58,16 @@ mod test {
     #[test]
     fn test_missing_command() {
         let m = Message::from_string("");
-        assert_eq!(m, Err(Error::MessageMissingCommand));
+        match m {
+            Err(Error::MessageMissingCommand) => (),
+            _ => panic!(),
+        }
 
         let m = Message::from_string(":me!me@irc.gitter.im");
-        assert_eq!(m, Err(Error::MessageMissingCommand));
+        match m {
+            Err(Error::MessageMissingCommand) => (),
+            _ => panic!(),
+        }
     }
 
     #[test]
@@ -69,6 +78,9 @@ mod test {
 
         let message = format!("{}{}", prefix_command, channel_name);
         let m = Message::from_string(&message);
-        assert_eq!(m, Err(Error::MessageStringTooLong));
+        match m {
+            Err(Error::MessageStringTooLong) => (),
+            _ => panic!(),
+        }
     }
 }


### PR DESCRIPTION
- custom defined error in `error.rs`
- integrate errors into parsing for `Message`
- add tests for errors

The errors:
    - MissingCommand
    - StringTooLong

Closes #5 

(Not sure I got the errors exactly right, but I guess you can check the test cases)

Also for discussion:

I put all crate-wide errors into one enum. Then I just "namespaced" the message errors. There's probably a better, but more complex pattern here, but I wanted to keep it simple.

I wasn't sure how much information you wanted to return for an error variant. In using other libraries, I've found that returning the source of the error (e.g. a faulty string) was left up to the user of the library, although something like line number might be provided by the library. Since this is a tutorial, I just kept it simple. (in prod, I'd probably send the error up with context using a helper lib).