### PR TITLE
Fewer lifetimes using String

### DIFF
--- a/src/irc/mod.rs
+++ b/src/irc/mod.rs
@@ -1,82 +1,74 @@
 use std::error::Error;
 
 use tokio::prelude::*;
-use tokio::{
-    io::BufReader,
-    net::TcpStream,
-};
+use tokio::{io::BufReader, net::TcpStream};
 
 pub mod message;
 pub use self::message::Message; // Re-export `Message` as part of irc module
 
 type LineHandler = fn(line: &Message) -> ();
 
-struct LineHandlerInfo<'a> {
-  label: &'a str,
+struct LineHandlerInfo {
+  label: String,
   f: LineHandler,
 }
 
-pub struct Protocol<'a, T = TcpStream>
-{
+pub struct Protocol<T = TcpStream> {
   nick: String,
   bufconn: BufReader<T>,
-  handlers: Vec<LineHandlerInfo<'a>>,
+  handlers: Vec<LineHandlerInfo>,
 }
 
 // T - tcp, tcp/tls, or test fake
-impl<'imp, Connection: AsyncRead + AsyncWrite + Unpin> Protocol<'imp, Connection>
-{
-    pub fn new(tcp: Connection, nick: String) -> Self
-    {
-      Protocol {
-        nick,
-        bufconn: BufReader::new(tcp),
-        handlers: Vec::new(),
-      }
+impl<Connection: AsyncRead + AsyncWrite + Unpin> Protocol<Connection> {
+  pub fn new(tcp: Connection, nick: String) -> Self {
+    Protocol {
+      nick,
+      bufconn: BufReader::new(tcp),
+      handlers: Vec::new(),
     }
+  }
 
-    pub async fn connect<'a>(&'a mut self, pass: &'a str) -> Result<(), Box<dyn Error>> {
-      let connect_str = format!("PASS {pass}\r\nNICK {name}\r\nUSER {name} 0 * {name}\r\n",
-          pass=pass, name=self.nick);
-      self.bufconn.write_all(connect_str.as_bytes()).await?;
+  pub async fn connect<'a>(&'a mut self, pass: &'a str) -> Result<(), Box<dyn Error>> {
+    let connect_str = format!(
+      "PASS {pass}\r\nNICK {name}\r\nUSER {name} 0 * {name}\r\n",
+      pass = pass,
+      name = self.nick
+    );
+    self.bufconn.write_all(connect_str.as_bytes()).await?;
 
-      Ok(())
-    }
+    Ok(())
+  }
 
-    // TODO: maybe name this send_command
-    pub async fn command<'a>(&'a mut self, cmd_str: &'a str) -> Result<(), std::io::Error> {
-      self.bufconn.write_all(cmd_str.as_bytes()).await
-    }
+  // TODO: maybe name this send_command
+  pub async fn command<'a>(&'a mut self, cmd_str: &'a str) -> Result<(), std::io::Error> {
+    self.bufconn.write_all(cmd_str.as_bytes()).await
+  }
 
-    // TODO: why not &'imp mut self ???
-    pub fn register_handler(&mut self, label: &'imp str, f: LineHandler) {
-      self.handlers.push(LineHandlerInfo {
-        label,
-        f,
-      })
-    }
+  // TODO: why not &'imp mut self ???
+  pub fn register_handler(&mut self, label: String, f: LineHandler) {
+    self.handlers.push(LineHandlerInfo { label, f })
+  }
 
-    pub async fn handle_lines(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-      let mut count = 0;
-      loop {
-        let mut response = String::new();
-        self.bufconn.read_line(&mut response).await?;
-        {
-          let message = Message::from_string(&response)
-              .ok_or("Could not parse message")?;
-          for info in &self.handlers {
-              (info.f)(&message);
-          }
+  pub async fn handle_lines(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    let mut count = 0;
+    loop {
+      let mut response = String::new();
+      self.bufconn.read_line(&mut response).await?;
+      {
+        let message = Message::from_string(&response).ok_or("Could not parse message")?;
+        for info in &self.handlers {
+          (info.f)(&message);
         }
-        count += 1;
-        if count > 18 {break};
+      }
+      count += 1;
+      if count > 18 {
+        break;
       };
-      Ok(())
     }
-
-
+    Ok(())
+  }
 }
-
 
 // impl<'imp> Session<'imp> {
 //   pub async fn new<'a>(addr: &'a str, nick: &'a str) -> Result<Session<'a>, Box<dyn Error>> {
@@ -128,8 +120,10 @@ async fn can_create_protocol() {
   use tokio_test::io::Builder;
   use tokio_test::io::Mock;
 
-  let mock_connection: Mock = Builder::new().write(b"PASS secret\r\nNICK maria\r\nUSER maria 0 * maria\r\n")
-                        .read(b":maria!maria@irc.gitter.im NICK :maria\r\n").build();
+  let mock_connection: Mock = Builder::new()
+    .write(b"PASS secret\r\nNICK maria\r\nUSER maria 0 * maria\r\n")
+    .read(b":maria!maria@irc.gitter.im NICK :maria\r\n")
+    .build();
 
   let mut irc = Protocol::new(mock_connection, "maria");
   irc.connect("secret").await.expect("irc.connect");

--- a/src/irc/mod.rs
+++ b/src/irc/mod.rs
@@ -29,7 +29,7 @@ impl<Connection: AsyncRead + AsyncWrite + Unpin> Protocol<Connection> {
     }
   }
 
-  pub async fn connect<'a>(&'a mut self, pass: &'a str) -> Result<(), Box<dyn Error>> {
+  pub async fn connect(&mut self, pass: &str) -> Result<(), Box<dyn Error>> {
     let connect_str = format!(
       "PASS {pass}\r\nNICK {name}\r\nUSER {name} 0 * {name}\r\n",
       pass = pass,
@@ -41,7 +41,7 @@ impl<Connection: AsyncRead + AsyncWrite + Unpin> Protocol<Connection> {
   }
 
   // TODO: maybe name this send_command
-  pub async fn command<'a>(&'a mut self, cmd_str: &'a str) -> Result<(), std::io::Error> {
+  pub async fn command(&mut self, cmd_str: &str) -> Result<(), std::io::Error> {
     self.bufconn.write_all(cmd_str.as_bytes()).await
   }
 
@@ -125,7 +125,7 @@ async fn can_create_protocol() {
     .read(b":maria!maria@irc.gitter.im NICK :maria\r\n")
     .build();
 
-  let mut irc = Protocol::new(mock_connection, "maria");
+  let mut irc = Protocol::new(mock_connection, "maria".into());
   irc.connect("secret").await.expect("irc.connect");
 
   // how to test that the write and read actually happened

--- a/src/irc/mod.rs
+++ b/src/irc/mod.rs
@@ -18,7 +18,7 @@ struct LineHandlerInfo<'a> {
 
 pub struct Protocol<'a, T = TcpStream>
 {
-  nick: &'a str,
+  nick: String,
   bufconn: BufReader<T>,
   handlers: Vec<LineHandlerInfo<'a>>,
 }
@@ -26,7 +26,7 @@ pub struct Protocol<'a, T = TcpStream>
 // T - tcp, tcp/tls, or test fake
 impl<'imp, Connection: AsyncRead + AsyncWrite + Unpin> Protocol<'imp, Connection>
 {
-    pub fn new(tcp: Connection, nick: &'imp str) -> Self
+    pub fn new(tcp: Connection, nick: String) -> Self
     {
       Protocol {
         nick,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let addr = "127.0.0.1:1234";
     let tcp = TcpStream::connect(addr).await?;
 
-    let mut irc = irc::Protocol::new(tcp, &irc_user);
+    let mut irc = irc::Protocol::new(tcp, irc_user);
 
     // // :ultrasaurus_twitter!ultrasaurus_twitter@irc.gitter.im JOIN #irc-tokio/community\r
     irc.register_handler("#irc-tokio/community JOIN response", |message| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,38 +1,39 @@
 use std::env;
 use std::error::Error;
-use tokio::{
-  net::TcpStream,
-};
+use tokio::net::TcpStream;
 
 mod irc;
 
 //https://docs.rs/tokio/0.2.0-alpha.5/tokio/net/tcp/struct.TcpStream.html
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let irc_user = env::var("USER")
-        .expect("USER environment var required. Perhaps you forgot to `source .env`");
-    let irc_pass = env::var("PASS")
-        .expect("PASS environment var required. Perhaps you forgot to `source .env`");
+  let irc_user =
+    env::var("USER").expect("USER environment var required. Perhaps you forgot to `source .env`");
+  let irc_pass =
+    env::var("PASS").expect("PASS environment var required. Perhaps you forgot to `source .env`");
 
-    // Connect to the server
+  // Connect to the server
 
-    let addr = "127.0.0.1:1234";
-    let tcp = TcpStream::connect(addr).await?;
+  let addr = "127.0.0.1:1234";
+  let tcp = TcpStream::connect(addr).await?;
 
-    let mut irc = irc::Protocol::new(tcp, irc_user);
+  let mut irc = irc::Protocol::new(tcp, irc_user);
 
-    // // :ultrasaurus_twitter!ultrasaurus_twitter@irc.gitter.im JOIN #irc-tokio/community\r
-    irc.register_handler("#irc-tokio/community JOIN response", |message| {
-      if message.command == "JOIN" {
-        println!("**** joined #ultrasaurus!\n {:?}\n {}\n {:?}\n", message.prefix, message.command, message.params);
-      }
-      ()
-    });
+  // // :ultrasaurus_twitter!ultrasaurus_twitter@irc.gitter.im JOIN #irc-tokio/community\r
+  irc.register_handler("#irc-tokio/community JOIN response".into(), |message| {
+    if message.command == "JOIN" {
+      println!(
+        "**** joined #ultrasaurus!\n {:?}\n {}\n {:?}\n",
+        message.prefix, message.command, message.params
+      );
+    }
+    ()
+  });
 
-    // // TODO: handle ping (maybe inside Session impl)
+  // // TODO: handle ping (maybe inside Session impl)
 
-    irc.connect(&irc_pass).await?;    // read loop
-    irc.command("JOIN #irc-tokio/community\r\n").await?;
-    irc.handle_lines().await?;
-    Ok(())
+  irc.connect(&irc_pass).await?; // read loop
+  irc.command("JOIN #irc-tokio/community\r\n").await?;
+  irc.handle_lines().await?;
+  Ok(())
 }


### PR DESCRIPTION
I was able to remove all lifetime annotations in Session impl 
and realized we can use `into()` in the test to convert literal string

I think making zero lifetimes for the main protocol implementation will make tutorial much nicer